### PR TITLE
Change dependencies to non-SNAPSHOT versions.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,12 +13,12 @@ crossPaths := false
 autoScalaLibrary := false
 
 libraryDependencies ++= Seq(
-    "org.apache.flume" % "flume-ng-core" % "1.7.0-SNAPSHOT"
+    "org.apache.flume" % "flume-ng-core" % "1.7.0"
       exclude("org.apache.httpcomponents", "httpclient")
       exclude("commons-lang", "commons-lang")
       exclude("org.slf4j", "slf4j-api")
       exclude("com.google.guava", "guava"),
-    "org.apache.flume" % "flume-ng-sdk" % "1.7.0-SNAPSHOT"
+    "org.apache.flume" % "flume-ng-sdk" % "1.7.0"
       exclude("org.apache.thrift", "libthrift"),
     "com.fasterxml.jackson.core" % "jackson-core" % "2.3.1",
     "junit" % "junit-dep" % "4.10" % "test",


### PR DESCRIPTION
Dependencies on flume-ng-core and flume-ng-sdk in version 1.7.0-SNAPSHOT
couldn't be automatically resolved by sbt, so I changed them to non-SNAPSHOT
versions, which can be automatically resolved from
https://repo1.maven.org/maven2/org/apache/flume/flume-ng-core/1.7.0/.